### PR TITLE
fix for service arguments error

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,11 +5,11 @@ services:
         public: false
     symfony_persia.jdate:
         class: SymfonyPersia\JalaliDateBundle\Service\JalaliDateTime
-        arguments: [ @symfony_persia.jdate_lib ]
+        arguments: [ '@symfony_persia.jdate_lib' ]
         public: true
     symfony_persia.jdate_extension:
         class: SymfonyPersia\JalaliDateBundle\Twig\JalaliDateExtension
-        arguments: [ @symfony_persia.jdate_lib ]
+        arguments: [ '@symfony_persia.jdate_lib' ]
         public: true
         tags:
             - { name: twig.extension }


### PR DESCRIPTION
Hi Mohammad.
When I was trying to add symfonypersia bundle to my Symfony 3.4 application, I got this error:
```
In YamlFileLoader.php line 669:

The file "vendor/symfony_persia/symfonyjdate/DependencyInjection/../Resources/config/services.yml" does not contain valid YAML.

In Inline.php line 350:                                                                                                                                                     
  The reserved indicator "@" cannot start a plain scalar; you need to quote the scalar at line 8 (near "arguments: [ @symfony_persia.jdate_lib ]").
```

my patch fixes this problem, please merge this fix to main repo to update our packagist bundle using composer!
Cheers!